### PR TITLE
ERROR state: Add NVRs from the second set if available

### DIFF
--- a/compare/compare.py
+++ b/compare/compare.py
@@ -116,7 +116,7 @@ class Comparison:
             return {
                 "status": self.status[-2],
                 "nvr1": None,
-                "nvr2": None,
+                "nvr2": None if not build2 else build2['nvr'],
             }
 
         if not build2:


### PR DESCRIPTION
Currently the output states there are no builds in the second set even
if there are.  The ERROR state signals the requested package is not
available in the first set, which is still correct.  This makes it
different from EXTRA.

However, None/None output is fairly misleading.  This should make the
situation fairly more obvious.

Signed-off-by: Petr Šabata <contyk@redhat.com>