### PR TITLE
Categorize certain ERROR components as NEW

### DIFF
--- a/compare/compare.py
+++ b/compare/compare.py
@@ -114,7 +114,7 @@ class Comparison:
         if not build1:
             logging.warning(f'Package {package} not found in {source1}')
             return {
-                "status": self.status[-2],
+                "status": self.status[-2] if not build2 else self.status[-1],
                 "nvr1": None,
                 "nvr2": None if not build2 else build2['nvr'],
             }


### PR DESCRIPTION
This change categorizes components previously categorized as ERROR as
NEW if they have a build in the downstream tag.

I think this is better than coupling them with the ones that have no
builds anywhere but probably still suboptimal.  Maybe a new status would
be better but I can't think of any good, descriptive words besides
MISSING.  But missing from where?  Naming is hard.

Signed-off-by: Petr Šabata <contyk@redhat.com>